### PR TITLE
[Hot Fix] - Move raygun require out of exported function event-handlers.js

### DIFF
--- a/lib/event-handlers.js
+++ b/lib/event-handlers.js
@@ -1,12 +1,10 @@
 'use strict';
 
-// If you put this in the exported function, the loaded cron jobs
-// are removed and none of the cron job listeners work!
 const raygun = require('rhmap-raygun-nodejs')();
+const later = require('later');
 
 module.exports = function (job, collection) {
   const log = require('./log')(job.meta.name);
-  const later = require('later');
 
   return {
     onTickStarted: () => {

--- a/lib/event-handlers.js
+++ b/lib/event-handlers.js
@@ -1,9 +1,12 @@
 'use strict';
 
+// If you put this in the exported function, the loaded cron jobs
+// are removed and none of the cron job listeners work!
+const raygun = require('rhmap-raygun-nodejs')();
+
 module.exports = function (job, collection) {
   const log = require('./log')(job.meta.name);
   const later = require('later');
-  const raygun = require('rhmap-raygun-nodejs')();
 
   return {
     onTickStarted: () => {


### PR DESCRIPTION
* Move raygun require above function export to prevent loaded cron jobs from being hosed.